### PR TITLE
feat: 주문내역 로그인한 유저의 이메일로 필터링

### DIFF
--- a/src/api/fetchProducts.tsx
+++ b/src/api/fetchProducts.tsx
@@ -15,7 +15,7 @@ import { TypeCategory, TypeOrderData, TypeProduct } from '@/types/common'
 export const fetchCategoryProducts = async (
   category: TypeCategory,
   pageParam: string | null,
-  orderByPrice: boolean = false,
+  orderByPrice: boolean = false
 ) => {
   const productsCol = collection(db, 'products')
 
@@ -26,10 +26,10 @@ export const fetchCategoryProducts = async (
       where('category', '==', category),
       orderBy(
         orderByPrice ? 'price' : 'createdAt',
-        orderByPrice ? 'asc' : 'desc',
+        orderByPrice ? 'asc' : 'desc'
       ), // 가격순은 오름차순으로 설정
       startAfter(pageParam || 0),
-      limit(4),
+      limit(4)
     )
   } else {
     q = query(
@@ -37,9 +37,9 @@ export const fetchCategoryProducts = async (
       where('category', '==', category),
       orderBy(
         orderByPrice ? 'price' : 'createdAt',
-        orderByPrice ? 'asc' : 'desc',
+        orderByPrice ? 'asc' : 'desc'
       ),
-      limit(4),
+      limit(4)
     )
   }
 
@@ -56,7 +56,7 @@ export const fetchCategoryProducts = async (
 // 상품 디테일 모달의 추천 상품 3가지
 export const fetchRecommendProduct = async (
   category: TypeCategory,
-  excludeProductId: string,
+  excludeProductId: string
 ) => {
   if (!category || !excludeProductId) {
     console.error('카테고리나 상품 ID가 undefined')
@@ -68,7 +68,7 @@ export const fetchRecommendProduct = async (
     where('category', '==', category),
     where(documentId(), '!=', excludeProductId),
     orderBy('createdAt', 'desc'),
-    limit(3),
+    limit(3)
   )
   const querySnapshot = await getDocs(q)
   const recommendProduct = querySnapshot.docs.map((doc) => ({
@@ -91,9 +91,13 @@ export const fetchSellerProducts = async () => {
 }
 
 // ORDER
-export const fetchOrderList = async () => {
+export const fetchOrderList = async (email: string) => {
   const orderCol = collection(db, 'orders')
-  const q = query(orderCol, orderBy('timestamp', 'desc'))
+  const q = query(
+    orderCol,
+    where('customer_email', '==', email),
+    orderBy('timestamp', 'desc')
+  )
 
   const querySnapshot = await getDocs(q)
   const orderlist = querySnapshot.docs.map((doc) => ({

--- a/src/api/productQueries.ts
+++ b/src/api/productQueries.ts
@@ -19,7 +19,7 @@ export const useQueryInitialProducts = (category: TypeCategory) => {
 // 카테고리 별 무한 스크롤 useInfiniteQuery
 export const useCategoryQueryProducts = (
   category: TypeCategory,
-  orderByPrice: boolean,
+  orderByPrice: boolean
 ) => {
   return useInfiniteQuery({
     queryKey: ['products', category, { orderByPrice }],
@@ -34,7 +34,7 @@ export const useCategoryQueryProducts = (
 
 export const useQueryRecommendProduct = (
   category: TypeCategory,
-  excludeProductId: string,
+  excludeProductId: string
 ) => {
   return useQuery({
     queryKey: ['Recommend', category, excludeProductId],
@@ -54,10 +54,11 @@ export const useQuerySellerProducts = () => {
 }
 
 // ORDER
-export const useQueryOrderList = () => {
+export const useQueryOrderList = (email: string) => {
   return useQuery({
-    queryKey: ['orders'],
-    queryFn: fetchOrderList,
+    queryKey: ['orders', email],
+    queryFn: () => fetchOrderList(email),
+    enabled: !!email,
     refetchOnWindowFocus: false,
   })
 }

--- a/src/components/Product/Cart.tsx
+++ b/src/components/Product/Cart.tsx
@@ -37,6 +37,10 @@ const Cart = ({ isCartVisible }: Props) => {
   }
   // 장바구니 정보를 DB에 담을 데이터로 가공하고 PaymentProvider의 updateOrderData함수로 전달
   const handlePlaceOrder = () => {
+    if (userProfile === null) {
+      alert('로그인이 필요합니다.')
+      return
+    }
     if (orderType === null) {
       alert('주문 방식을 선택해주세요.')
       return
@@ -82,7 +86,7 @@ const Cart = ({ isCartVisible }: Props) => {
                 <Button
                   onClick={() => handlerOrderType('Dine in')}
                   className={`rounded-3xl b border hover:text-white ${getButtonStyle(
-                    'Dine in',
+                    'Dine in'
                   )}`}
                 >
                   Dine in
@@ -90,14 +94,14 @@ const Cart = ({ isCartVisible }: Props) => {
                 <Button
                   onClick={() => handlerOrderType('Take out')}
                   className={`rounded-3xl b border hover:text-white ${getButtonStyle(
-                    'Take out',
+                    'Take out'
                   )}`}
                 >
                   Take away
                 </Button>
                 <Button
                   className={`rounded-3xl b border hover:text-white ${getButtonStyle(
-                    'Delivery',
+                    'Delivery'
                   )}`}
                   disabled
                 >

--- a/src/components/common/Category.tsx
+++ b/src/components/common/Category.tsx
@@ -6,7 +6,6 @@ interface Props {
 }
 
 const Category = () => {
-  console.log('Category 컴포넌트 렌더링')
   return (
     <div className="w-[350px] flex gap-3">
       <CategoryButton to="/coffee" label="Coffee" />

--- a/src/components/common/Nav.tsx
+++ b/src/components/common/Nav.tsx
@@ -15,7 +15,6 @@ interface Props {
   sellerHome?: boolean
 }
 const Nav = ({ customerMenu, sellerHome }: Props) => {
-  console.log('Nav 컴포넌트 렌더링')
   const userProfile = useCurrentUser()
 
   const cartContext = useCart()

--- a/src/pages/MyOrder.tsx
+++ b/src/pages/MyOrder.tsx
@@ -1,15 +1,19 @@
 import { useQueryOrderList } from '@/api/productQueries'
 import Loading from '@/components/common/Loading'
 import PageLayout from '@/components/common/PageLayout'
+import useCurrentUser from '@/hooks/useCurrentUser'
 import { Suspense, lazy } from 'react'
 const MyOrderList = lazy(() => import('@/components/order/MyOrderList'))
 
 const MyOrder = () => {
-  const { data } = useQueryOrderList()
+  const { email } = useCurrentUser() || {}
+  const { data } = useQueryOrderList(email!)
 
   return (
     <PageLayout>
       <section className="max-h-[770px] overflow-y-auto min-w-[700px] space-y-5 gap-5 flex flex-col">
+        {!email && <div>로그인이 필요합니다.</div>}
+        {data?.length === 0 && <div>주문내역이 없습니다.</div>}
         {data?.map((order) => (
           <Suspense fallback={<Loading />} key={order.order_id}>
             <MyOrderList data={order} />

--- a/src/pages/seller/OrderHistory.tsx
+++ b/src/pages/seller/OrderHistory.tsx
@@ -4,9 +4,11 @@ import { sellerMenu } from '@/components/common/MenuItem'
 import { useQueryOrderList } from '@/api/productQueries'
 import SellerOrderHistory from '@/components/SellerOrderHistory/SellerOrderList'
 import { Helmet } from 'react-helmet-async'
+import useCurrentUser from '@/hooks/useCurrentUser'
 
 const OrderHistory = () => {
-  const { data } = useQueryOrderList()
+  const { email } = useCurrentUser() || {}
+  const { data } = useQueryOrderList(email!)
   return (
     <main className="bg-gray-50 flex">
       <Helmet>


### PR DESCRIPTION
# 주문 내역 페이지를 개선
이메일 필터링 기능과 조건부 렌더링을 추가하였습니다.

### 이메일 필터링 기능 추가:

사용자가 로그인하면, 해당 사용자의 이메일을 기반으로 데이터베이스에서 주문 내역을 필터링합니다.
이를 통해 다른 사용자의 주문 내역을 혼동 없이 보여줄 수 있습니다.
페치 함수(fetchOrderList)는 이메일을 인자로 받아서 데이터베이스에서 해당 사용자의 주문 데이터를 가져옵니다.

### 조건부 렌더링 적용:

#### 로그인 필요 메시지: 
사용자가 로그인하지 않은 경우, "로그인이 필요합니다."라는 메시지를 표시합니다.
#### 주문 내역 없음 메시지: 
사용자가 로그인했지만 주문 내역이 없는 경우, "주문 내역이 없습니다."라는 메시지를 표시합니다.
#### 주문 내역 목록: 
로그인하고 주문 내역이 있는 경우, 각 주문을 리스트로 표시합니다.

### 페치 함수(fetchOrderList):

주문 내역을 가져오는 데 사용되며, 사용자의 이메일을 기준으로 데이터를 필터링합니다.
데이터는 최신 순으로 정렬하여 사용자에게 보다 직관적이고 효율적인 방식으로 제공됩니다.

### 유즈쿼리 훅(useQueryOrderList)의 변경사항:
사용자의 이메일 여부를 확인하여, 로그인한 경우에만 해당 사용자의 주문 내역을 필터링하도록 조건을 추가했습니다.
이를 위해 enabled 옵션에 !!email을 사용하여 이메일이 존재할 경우 true로 설정하고, 이를 기반으로 특정 사용자의 주문 내역만 가져옵니다.

```js
export const fetchOrderList = async (email: string) => {
  const orderCol = collection(db, 'orders')
  const q = query(
    orderCol,
    where('customer_email', '==', email), // 추가한 부분
    orderBy('timestamp', 'desc')
  )
  중략
  
export const useQueryOrderList = (email: string) => {
  return useQuery({
    queryKey: ['orders', email],
    queryFn: () => fetchOrderList(email),
    enabled: !!email, // 추가한 부분
    refetchOnWindowFocus: false,
  })
}
```